### PR TITLE
Made the menu load the current meal period

### DIFF
--- a/Bruin Bite/View Controllers/MenuVC.swift
+++ b/Bruin Bite/View Controllers/MenuVC.swift
@@ -43,6 +43,37 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
         topBar.frame = CGRect(x:12.5, y:20, width: 350, height: 82)
         topBar.center.x = self.view.center.x
         self.view.addSubview(topBar)
+        
+        let hour = Calendar.current.component(.hour, from: Date())
+        switch hour {
+        case 0..<2:
+            self.topBar.timeSelected("Night")
+        case 2..<9:
+            if(!self.topBar.brunch) {
+                self.topBar.timeSelected("Breakfast")
+            }
+            else {
+                self.topBar.timeSelected("Brunch")
+            }
+        case 9..<15:
+            if(!self.topBar.brunch) {
+                self.topBar.timeSelected("Lunch")
+            }
+            else {
+                self.topBar.timeSelected("Brunch")
+            }
+        case 15..<21:
+            self.topBar.timeSelected("Dinner")
+        case 21..<24:
+            self.topBar.timeSelected("Night")
+        default:
+            print("Current Meal Period could not be determined")
+        }
+        
+        if let dateLbl = self.topBar.dayBtns[1].dateLbl.text, let dayLbl = self.topBar.dayBtns[1].dateLbl.text {
+            self.topBar.daySelected(dateLbl, dayLabel: dayLbl)
+        }
+        
         // Do any additional setup after loading the view, typically from a nib.
         API.getCurrentActivityLevels { (activityLevels) in
             for a in activityLevels{
@@ -61,32 +92,7 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
             let date = Date()
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "d"
-            let hour = Calendar.current.component(.hour, from: Date())
-            switch hour {
-            case 0..<2:
-                self.topBar.timeSelected("Night")
-            case 2..<9:
-                if(!self.topBar.brunch) {
-                    self.topBar.timeSelected("Breakfast")
-                }
-                else {
-                    self.topBar.timeSelected("Brunch")
-                }
-            case 9..<15:
-                if(!self.topBar.brunch) {
-                    self.topBar.timeSelected("Lunch")
-                }
-                else {
-                    self.topBar.timeSelected("Brunch")
-                }
-            case 15..<21:
-                self.topBar.timeSelected("Dinner")
-            case 21..<24:
-                self.topBar.timeSelected("Night")
-            default:
-                print("Current Meal Period could not be determined")
-                self.currMP = MealPeriod.breakfast
-            }
+            
             self.updateData(dateFormatter.string(from: date), mP: self.currMP)
         }
 //        API.getDetailedMenu { parsedMenus in

--- a/Bruin Bite/View Controllers/MenuVC.swift
+++ b/Bruin Bite/View Controllers/MenuVC.swift
@@ -61,7 +61,33 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
             let date = Date()
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "d"
-            self.updateData(dateFormatter.string(from: date), mP: MealPeriod.breakfast)
+            let hour = Calendar.current.component(.hour, from: Date())
+            switch hour {
+            case 0..<2:
+                self.topBar.timeSelected("Night")
+            case 2..<9:
+                if(!self.topBar.brunch) {
+                    self.topBar.timeSelected("Breakfast")
+                }
+                else {
+                    self.topBar.timeSelected("Brunch")
+                }
+            case 9..<15:
+                if(!self.topBar.brunch) {
+                    self.topBar.timeSelected("Lunch")
+                }
+                else {
+                    self.topBar.timeSelected("Brunch")
+                }
+            case 15..<21:
+                self.topBar.timeSelected("Dinner")
+            case 21..<24:
+                self.topBar.timeSelected("Night")
+            default:
+                print("Current Meal Period could not be determined")
+                self.currMP = MealPeriod.breakfast
+            }
+            self.updateData(dateFormatter.string(from: date), mP: self.currMP)
         }
 //        API.getDetailedMenu { parsedMenus in
 //            for m in parsedMenus{


### PR DESCRIPTION
The menu should open the current meal period when first opened.
The menu also loads right away now.

One bug still persists: the dining hall hours don't load at first.

Current meal period is determined by the current time:
12am- 2am Latenight
2am - 9am Breakfast (Brunch on sun/sat)
9am - 3pm Lunch (brunch on sun/sat)
3pm - 9pm Dinner
9pm -12am Latenight